### PR TITLE
增加搜索引擎管理，管理员侧边栏展开状态持久化，首页空分类

### DIFF
--- a/database/init.db.go
+++ b/database/init.db.go
@@ -237,4 +237,26 @@ func InitDB() {
 	}
 	rows.Close()
 	logger.LogInfo("数据库初始化成功💗")
+
+	// 清理空分类记录 - 删除名称为空或只包含空白字符的分类
+	cleanupEmptyCategories()
+}
+
+// cleanupEmptyCategories 清理空分类记录
+func cleanupEmptyCategories() {
+	// 删除名称为空或只包含空白字符的分类记录
+	sql_cleanup := `
+		DELETE FROM nav_catelog 
+		WHERE name IS NULL OR name = '' OR TRIM(name) = '';
+	`
+	result, err := DB.Exec(sql_cleanup)
+	if err != nil {
+		logger.LogInfo("清理空分类记录时出错: %v", err)
+		return
+	}
+	
+	rowsAffected, err := result.RowsAffected()
+	if err == nil && rowsAffected > 0 {
+		logger.LogInfo("已清理 %d 条空分类记录", rowsAffected)
+	}
 }

--- a/database/init.db.go
+++ b/database/init.db.go
@@ -166,11 +166,17 @@ func InitDB() {
 	sql_create_table = `
 		CREATE TABLE IF NOT EXISTS nav_site_config (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			noImageMode BOOLEAN NOT NULL DEFAULT 0
+			noImageMode BOOLEAN NOT NULL DEFAULT 0,
+			compactMode BOOLEAN NOT NULL DEFAULT 0
 		);
 		`
 	_, err = DB.Exec(sql_create_table)
 	utils.CheckErr(err)
+	
+	// 网站配置表结构升级 - 添加compactMode列
+	if !columnExists("nav_site_config", "compactMode") {
+		DB.Exec(`ALTER TABLE nav_site_config ADD COLUMN compactMode BOOLEAN NOT NULL DEFAULT 0;`)
+	}
 	
 	// 如果不存在，就初始化默认搜索引擎
 	sql_get_search_engine := `
@@ -255,12 +261,12 @@ func InitDB() {
 	utils.CheckErr(err)
 	if !rows.Next() {
 		sql_add_site_config := `
-			INSERT INTO nav_site_config (noImageMode)
-			VALUES (?);
+			INSERT INTO nav_site_config (noImageMode, compactMode)
+			VALUES (?, ?);
 			`
 		stmt, err := DB.Prepare(sql_add_site_config)
 		utils.CheckErr(err)
-		res, err := stmt.Exec(false)
+		res, err := stmt.Exec(false, false)
 		utils.CheckErr(err)
 		_, err = res.LastInsertId()
 		utils.CheckErr(err)

--- a/database/init.db.go
+++ b/database/init.db.go
@@ -161,6 +161,16 @@ func InitDB() {
 		`
 	_, err = DB.Exec(sql_create_table)
 	utils.CheckErr(err)
+
+	// 网站配置表
+	sql_create_table = `
+		CREATE TABLE IF NOT EXISTS nav_site_config (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			noImageMode BOOLEAN NOT NULL DEFAULT 0
+		);
+		`
+	_, err = DB.Exec(sql_create_table)
+	utils.CheckErr(err)
 	
 	// 如果不存在，就初始化默认搜索引擎
 	sql_get_search_engine := `
@@ -231,6 +241,26 @@ func InitDB() {
 		stmt, err := DB.Prepare(sql_add_setting)
 		utils.CheckErr(err)
 		res, err := stmt.Exec("favicon.ico", "Van Nav", "", "logo192.png", "logo512.png", false, false, true)
+		utils.CheckErr(err)
+		_, err = res.LastInsertId()
+		utils.CheckErr(err)
+	}
+	rows.Close()
+
+	// 如果不存在网站配置，就初始化
+	sql_get_site_config := `
+		SELECT * FROM nav_site_config;
+		`
+	rows, err = DB.Query(sql_get_site_config)
+	utils.CheckErr(err)
+	if !rows.Next() {
+		sql_add_site_config := `
+			INSERT INTO nav_site_config (noImageMode)
+			VALUES (?);
+			`
+		stmt, err := DB.Prepare(sql_add_site_config)
+		utils.CheckErr(err)
+		res, err := stmt.Exec(false)
 		utils.CheckErr(err)
 		_, err = res.LastInsertId()
 		utils.CheckErr(err)

--- a/database/operations.go
+++ b/database/operations.go
@@ -1,5 +1,7 @@
 package database
 
+import "github.com/mereith/nav/types"
+
 func HasApiToken(token string) bool {
 	sql := `SELECT value FROM nav_api_token WHERE value = ? and disabled = 0`
 	rows, err := DB.Query(sql, token)
@@ -12,4 +14,125 @@ func HasApiToken(token string) bool {
 		return true
 	}
 	return false
+}
+
+// ==================== 搜索引擎相关操作 ====================
+
+// 获取所有搜索引擎（按排序）
+func GetAllSearchEngines() ([]types.SearchEngine, error) {
+	sql := `SELECT id, name, baseUrl, queryParam, logo, sort, enabled FROM nav_search_engine ORDER BY sort ASC`
+	rows, err := DB.Query(sql)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var engines []types.SearchEngine
+	for rows.Next() {
+		var engine types.SearchEngine
+		err := rows.Scan(&engine.Id, &engine.Name, &engine.BaseUrl, &engine.QueryParam, &engine.Logo, &engine.Sort, &engine.Enabled)
+		if err != nil {
+			return nil, err
+		}
+		engines = append(engines, engine)
+	}
+	return engines, nil
+}
+
+// 获取启用的搜索引擎（按排序）
+func GetEnabledSearchEngines() ([]types.SearchEngine, error) {
+	sql := `SELECT id, name, baseUrl, queryParam, logo, sort, enabled FROM nav_search_engine WHERE enabled = 1 ORDER BY sort ASC`
+	rows, err := DB.Query(sql)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var engines []types.SearchEngine
+	for rows.Next() {
+		var engine types.SearchEngine
+		err := rows.Scan(&engine.Id, &engine.Name, &engine.BaseUrl, &engine.QueryParam, &engine.Logo, &engine.Sort, &engine.Enabled)
+		if err != nil {
+			return nil, err
+		}
+		engines = append(engines, engine)
+	}
+	return engines, nil
+}
+
+// 添加搜索引擎
+func AddSearchEngine(engine types.SearchEngine) (int64, error) {
+	// 获取最大排序值
+	var maxSort int
+	err := DB.QueryRow(`SELECT COALESCE(MAX(sort), 0) FROM nav_search_engine`).Scan(&maxSort)
+	if err != nil {
+		return 0, err
+	}
+	
+	sql := `INSERT INTO nav_search_engine (name, baseUrl, queryParam, logo, sort, enabled) VALUES (?, ?, ?, ?, ?, ?)`
+	stmt, err := DB.Prepare(sql)
+	if err != nil {
+		return 0, err
+	}
+	defer stmt.Close()
+	
+	result, err := stmt.Exec(engine.Name, engine.BaseUrl, engine.QueryParam, engine.Logo, maxSort+1, engine.Enabled)
+	if err != nil {
+		return 0, err
+	}
+	
+	return result.LastInsertId()
+}
+
+// 更新搜索引擎
+func UpdateSearchEngine(engine types.SearchEngine) error {
+	sql := `UPDATE nav_search_engine SET name = ?, baseUrl = ?, queryParam = ?, logo = ?, enabled = ? WHERE id = ?`
+	stmt, err := DB.Prepare(sql)
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+	
+	_, err = stmt.Exec(engine.Name, engine.BaseUrl, engine.QueryParam, engine.Logo, engine.Enabled, engine.Id)
+	return err
+}
+
+// 删除搜索引擎
+func DeleteSearchEngine(id int) error {
+	sql := `DELETE FROM nav_search_engine WHERE id = ?`
+	stmt, err := DB.Prepare(sql)
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+	
+	_, err = stmt.Exec(id)
+	return err
+}
+
+// 更新搜索引擎排序
+func UpdateSearchEngineSort(sortData []struct {
+	Id   int `json:"id"`
+	Sort int `json:"sort"`
+}) error {
+	tx, err := DB.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	
+	stmt, err := tx.Prepare(`UPDATE nav_search_engine SET sort = ? WHERE id = ?`)
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+	
+	for _, item := range sortData {
+		_, err = stmt.Exec(item.Sort, item.Id)
+		if err != nil {
+			return err
+		}
+	}
+	
+	return tx.Commit()
 }

--- a/handler/handlers.go
+++ b/handler/handlers.go
@@ -146,6 +146,32 @@ func UpdateUserHandler(c *gin.Context) {
 	})
 }
 
+func UpdateSiteConfigHandler(c *gin.Context) {
+	var data types.SiteConfig
+	if err := c.ShouldBindJSON(&data); err != nil {
+		utils.CheckErr(err)
+		c.JSON(http.StatusBadRequest, gin.H{
+			"success":      false,
+			"errorMessage": err.Error(),
+		})
+		return
+	}
+	logger.LogInfo("更新网站配置: %+v", data)
+	err := service.UpdateSiteConfig(data)
+	if err != nil {
+		utils.CheckErr(err)
+		c.JSON(http.StatusBadRequest, gin.H{
+			"success":      false,
+			"errorMessage": err.Error(),
+		})
+		return
+	}
+	c.JSON(200, gin.H{
+		"success": true,
+		"message": "更新网站配置成功",
+	})
+}
+
 func GetAllHandler(c *gin.Context) {
 	tools := service.GetAllTool()
 	// 获取全部数据
@@ -159,12 +185,14 @@ func GetAllHandler(c *gin.Context) {
 		catelogs = utils.FilterHideCates(catelogs)
 	}
 	setting := service.GetSetting()
+	siteConfig := service.GetSiteConfig()
 	c.JSON(200, gin.H{
 		"success": true,
 		"data": gin.H{
-			"tools":    tools,
-			"catelogs": catelogs,
-			"setting":  setting,
+			"tools":      tools,
+			"catelogs":   catelogs,
+			"setting":    setting,
+			"siteConfig": siteConfig,
 		},
 	})
 }
@@ -211,6 +239,7 @@ func GetAdminAllDataHandler(c *gin.Context) {
 	tools := service.GetAllTool()
 	catelogs := service.GetAllCatelog()
 	setting := service.GetSetting()
+	siteConfig := service.GetSiteConfig()
 	tokens := service.GetApiTokens()
 	userId, ok := c.Get("uid")
 	if !ok {
@@ -223,9 +252,10 @@ func GetAdminAllDataHandler(c *gin.Context) {
 	c.JSON(200, gin.H{
 		"success": true,
 		"data": gin.H{
-			"tools":    tools,
-			"catelogs": catelogs,
-			"setting":  setting,
+			"tools":      tools,
+			"catelogs":   catelogs,
+			"setting":    setting,
+			"siteConfig": siteConfig,
 			"user": gin.H{
 				"name": c.GetString("username"),
 				"id":   userId,

--- a/handler/handlers.go
+++ b/handler/handlers.go
@@ -494,3 +494,163 @@ func UpdateToolsSortHandler(c *gin.Context) {
 		"message": "更新排序成功",
 	})
 }
+
+// ==================== 搜索引擎相关处理函数 ====================
+
+// 获取所有搜索引擎
+func GetAllSearchEnginesHandler(c *gin.Context) {
+	engines, err := database.GetAllSearchEngines()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"success":      false,
+			"errorMessage": err.Error(),
+		})
+		return
+	}
+	c.JSON(200, gin.H{
+		"success": true,
+		"data":    engines,
+	})
+}
+
+// 获取启用的搜索引擎（用于前端搜索功能）
+func GetEnabledSearchEnginesHandler(c *gin.Context) {
+	engines, err := database.GetEnabledSearchEngines()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"success":      false,
+			"errorMessage": err.Error(),
+		})
+		return
+	}
+	c.JSON(200, gin.H{
+		"success": true,
+		"data":    engines,
+	})
+}
+
+// 添加搜索引擎
+func AddSearchEngineHandler(c *gin.Context) {
+	var engine types.SearchEngine
+	err := c.ShouldBindJSON(&engine)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"success":      false,
+			"errorMessage": err.Error(),
+		})
+		return
+	}
+	
+	id, err := database.AddSearchEngine(engine)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"success":      false,
+			"errorMessage": err.Error(),
+		})
+		return
+	}
+	
+	c.JSON(200, gin.H{
+		"success": true,
+		"message": "添加搜索引擎成功",
+		"data": gin.H{
+			"id": id,
+		},
+	})
+}
+
+// 更新搜索引擎
+func UpdateSearchEngineHandler(c *gin.Context) {
+	var engine types.SearchEngine
+	err := c.ShouldBindJSON(&engine)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"success":      false,
+			"errorMessage": err.Error(),
+		})
+		return
+	}
+	
+	// 从URL参数获取ID
+	idStr := c.Param("id")
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"success":      false,
+			"errorMessage": "无效的ID",
+		})
+		return
+	}
+	engine.Id = id
+	
+	err = database.UpdateSearchEngine(engine)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"success":      false,
+			"errorMessage": err.Error(),
+		})
+		return
+	}
+	
+	c.JSON(200, gin.H{
+		"success": true,
+		"message": "更新搜索引擎成功",
+	})
+}
+
+// 删除搜索引擎
+func DeleteSearchEngineHandler(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"success":      false,
+			"errorMessage": "无效的ID",
+		})
+		return
+	}
+	
+	err = database.DeleteSearchEngine(id)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"success":      false,
+			"errorMessage": err.Error(),
+		})
+		return
+	}
+	
+	c.JSON(200, gin.H{
+		"success": true,
+		"message": "删除搜索引擎成功",
+	})
+}
+
+// 更新搜索引擎排序
+func UpdateSearchEngineSortHandler(c *gin.Context) {
+	var sortData []struct {
+		Id   int `json:"id"`
+		Sort int `json:"sort"`
+	}
+	err := c.ShouldBindJSON(&sortData)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"success":      false,
+			"errorMessage": err.Error(),
+		})
+		return
+	}
+	
+	err = database.UpdateSearchEngineSort(sortData)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"success":      false,
+			"errorMessage": err.Error(),
+		})
+		return
+	}
+	
+	c.JSON(200, gin.H{
+		"success": true,
+		"message": "更新排序成功",
+	})
+}

--- a/main.go
+++ b/main.go
@@ -99,6 +99,8 @@ func main() {
 
 			admin.PUT("/setting", handler.UpdateSettingHandler)
 
+			admin.PUT("/siteConfig", handler.UpdateSiteConfigHandler)
+
 			admin.POST("/tool", handler.AddToolHandler)
 			admin.DELETE("/tool/:id", handler.DeleteToolHandler)
 			admin.PUT("/tool/:id", handler.UpdateToolHandler)

--- a/main.go
+++ b/main.go
@@ -79,6 +79,10 @@ func main() {
 		api.POST("/login", handler.LoginHandler)
 		api.GET("/logout", handler.LogoutHandler)
 		api.GET("/img", handler.GetLogoImgHandler)
+		
+		// 获取启用的搜索引擎（公开接口）
+		api.GET("/searchEngines", handler.GetEnabledSearchEnginesHandler)
+		
 		// 管理员用的
 		admin := api.Group("/admin")
 		admin.Use(middleware.JWTMiddleware())
@@ -103,6 +107,13 @@ func main() {
 			admin.POST("/catelog", handler.AddCatelogHandler)
 			admin.DELETE("/catelog/:id", handler.DeleteCatelogHandler)
 			admin.PUT("/catelog/:id", handler.UpdateCatelogHandler)
+			
+			// 搜索引擎管理路由
+			admin.GET("/searchEngine", handler.GetAllSearchEnginesHandler)
+			admin.POST("/searchEngine", handler.AddSearchEngineHandler)
+			admin.PUT("/searchEngine/:id", handler.UpdateSearchEngineHandler)
+			admin.DELETE("/searchEngine/:id", handler.DeleteSearchEngineHandler)
+			admin.PUT("/searchEngines/sort", handler.UpdateSearchEngineSortHandler)
 		}
 	}
 	logger.LogInfo("应用启动成功，网址: http://localhost:%s", *port)

--- a/service/catelog.go
+++ b/service/catelog.go
@@ -4,6 +4,7 @@ import (
 	"github.com/mereith/nav/database"
 	"github.com/mereith/nav/types"
 	"github.com/mereith/nav/utils"
+	"strings"
 )
 
 func UpdateCatelog(data types.UpdateCatelogDto) {
@@ -51,6 +52,11 @@ func UpdateCatelog(data types.UpdateCatelogDto) {
 }
 
 func AddCatelog(data types.AddCatelogDto) {
+	// 检查分类名称是否为空，如果为空则不创建
+	if data.Name == "" || strings.TrimSpace(data.Name) == "" {
+		return
+	}
+	
 	// 先检查重复不重复
 	existCatelogs := GetAllCatelog()
 	var existCatelogsArr []string

--- a/service/site_config.go
+++ b/service/site_config.go
@@ -1,0 +1,61 @@
+package service
+
+import (
+	"github.com/mereith/nav/database"
+	"github.com/mereith/nav/logger"
+	"github.com/mereith/nav/types"
+)
+
+func GetSiteConfig() types.SiteConfig {
+	sql_get_site_config := `
+		SELECT id, noImageMode 
+		FROM nav_site_config 
+		ORDER BY id ASC 
+		LIMIT 1;
+		`
+	var siteConfig types.SiteConfig
+	row := database.DB.QueryRow(sql_get_site_config)
+	var noImageMode interface{}
+	err := row.Scan(&siteConfig.Id, &noImageMode)
+	if err != nil {
+		logger.LogError("获取网站配置失败: %s", err)
+		return types.SiteConfig{
+			Id:          1,
+			NoImageMode: false,
+		}
+	}
+	
+	if noImageMode == nil {
+		siteConfig.NoImageMode = false
+	} else {
+		if noImageMode.(int64) == 0 {
+			siteConfig.NoImageMode = false
+		} else {
+			siteConfig.NoImageMode = true
+		}
+	}
+
+	return siteConfig
+}
+
+func UpdateSiteConfig(data types.SiteConfig) error {
+	sql_update_site_config := `
+		UPDATE nav_site_config
+		SET noImageMode = ?
+		WHERE id = (SELECT id FROM nav_site_config ORDER BY id ASC LIMIT 1);
+		`
+
+	stmt, err := database.DB.Prepare(sql_update_site_config)
+	if err != nil {
+		return err
+	}
+	res, err := stmt.Exec(data.NoImageMode)
+	if err != nil {
+		return err
+	}
+	_, err = res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/service/tools.go
+++ b/service/tools.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"strings"
 	"sync"
 
 	"github.com/mereith/nav/database"
@@ -12,7 +13,8 @@ import (
 func ImportTools(data []types.Tool) {
 	var catelogs []string
 	for _, v := range data {
-		if !utils.In(v.Catelog, catelogs) {
+		// 过滤掉空分类，只收集有效的分类名称
+		if v.Catelog != "" && strings.TrimSpace(v.Catelog) != "" && !utils.In(v.Catelog, catelogs) {
 			catelogs = append(catelogs, v.Catelog)
 		}
 		sql_add_tool := `

--- a/types/types.go
+++ b/types/types.go
@@ -64,4 +64,5 @@ type SearchEngine struct {
 type SiteConfig struct {
 	Id          int  `json:"id"`
 	NoImageMode bool `json:"noImageMode"`
+	CompactMode bool `json:"compactMode"`
 }

--- a/types/types.go
+++ b/types/types.go
@@ -59,3 +59,9 @@ type SearchEngine struct {
 	Sort        int    `json:"sort"`
 	Enabled     bool   `json:"enabled"`
 }
+
+// 网站配置模型
+type SiteConfig struct {
+	Id          int  `json:"id"`
+	NoImageMode bool `json:"noImageMode"`
+}

--- a/types/types.go
+++ b/types/types.go
@@ -48,3 +48,14 @@ type Catelog struct {
 	Sort int    `json:"sort"`
 	Hide bool   `json:"hide"`
 }
+
+// 搜索引擎模型
+type SearchEngine struct {
+	Id          int    `json:"id"`
+	Name        string `json:"name"`
+	BaseUrl     string `json:"baseUrl"`
+	QueryParam  string `json:"queryParam"`
+	Logo        string `json:"logo"`
+	Sort        int    `json:"sort"`
+	Enabled     bool   `json:"enabled"`
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -15,6 +15,7 @@ const Tools = React.lazy(() => import('./pages/admin/tabs/Tools').then(module =>
 const Catelog = React.lazy(() => import('./pages/admin/tabs/Catelog').then(module => ({ default: module.Catelog })));
 const ApiToken = React.lazy(() => import('./pages/admin/tabs/ApiToken').then(module => ({ default: module.ApiToken })));
 const Setting = React.lazy(() => import('./pages/admin/tabs/Setting').then(module => ({ default: module.Setting })));
+const SearchEngine = React.lazy(() => import('./pages/admin/tabs/Search'));
 
 // 加载中的占位组件
 const LoadingFallback = () => {
@@ -71,6 +72,7 @@ function App() {
               <Route index element={<Tools />} />
               <Route path="tools" element={<Tools />} />
               <Route path="categories" element={<Catelog />} />
+              <Route path="search-engines" element={<SearchEngine />} />
               <Route path="api-token" element={<ApiToken />} />
               <Route path="settings" element={<Setting />} />
             </Route>

--- a/ui/src/components/CardV2/index.css
+++ b/ui/src/components/CardV2/index.css
@@ -16,3 +16,58 @@
 body.dark-mode .card-index {
     color: rgba(255,255,255, 0.6)
 }
+
+/* 精简模式样式 - 单行布局 */
+.card-content.compact-mode {
+    display: flex;
+    align-items: center;
+    min-height: auto;
+    height: auto;
+    flex-direction: row;
+    text-align: left;
+}
+
+.card-content.compact-mode .card-left {
+    margin-right: 8px;
+    margin-bottom: 0;
+    flex-shrink: 0;
+}
+
+.card-content.compact-mode .card-right {
+    flex: 1;
+    overflow: hidden;
+    height: auto;
+    display: flex;
+    align-items: center;
+}
+
+.card-content.compact-mode .card-right-top {
+    margin-bottom: 0;
+    height: auto;
+    width: 100%;
+    justify-content: flex-start;
+    align-items: center;
+}
+
+.card-content.compact-mode .card-right-title {
+    line-height: 1.2;
+    text-align: left;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    width: 100%;
+}
+
+.card-content.compact-mode .card-right-bottom {
+    display: none;
+}
+
+.card-content.compact-mode .card-tag {
+    display: none;
+}
+
+.card-content.compact-mode .card-left > img,
+.card-content.compact-mode .card-left embed {
+    width: 24px;
+    height: 24px;
+}

--- a/ui/src/components/CardV2/index.css
+++ b/ui/src/components/CardV2/index.css
@@ -71,3 +71,47 @@ body.dark-mode .card-index {
     width: 24px;
     height: 24px;
 }
+
+/* 确保card-left有相对定位以便加载指示器正确显示 */
+.card-left {
+    position: relative;
+}
+
+/* 加载指示器基础样式 */
+.card-loading-spinner {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 16px;
+    height: 16px;
+    border: 2px solid #e5e5e5;
+    border-top: 2px solid #999;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+    z-index: 1;
+}
+
+/* 精简模式下的加载指示器调整 */
+.card-content.compact-mode .card-loading-spinner {
+    width: 12px;
+    height: 12px;
+    border-width: 1.5px;
+}
+
+/* 懒加载动画 */
+@keyframes spin {
+    0% { transform: translate(-50%, -50%) rotate(0deg); }
+    100% { transform: translate(-50%, -50%) rotate(360deg); }
+}
+
+/* 暗色模式下的加载样式 */
+body.dark-mode .card-loading-spinner {
+    border: 2px solid #404040;
+    border-top: 2px solid #888;
+}
+
+body.dark-mode .card-content.compact-mode .card-loading-spinner {
+    border-width: 1.5px;
+}
+

--- a/ui/src/components/CardV2/index.tsx
+++ b/ui/src/components/CardV2/index.tsx
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import "./index.css";
 import { getLogoUrl } from "../../utils/check";
 import { getJumpTarget } from "../../utils/setting";
-const Card = ({ title, url, des, logo, catelog, onClick, index, isSearching, noImageMode }) => {
+const Card = ({ title, url, des, logo, catelog, onClick, index, isSearching, noImageMode, compactMode }) => {
   const el = useMemo(() => {
     if (url === "admin") {
       return <img src={logo} alt={title} />
@@ -30,7 +30,7 @@ const Card = ({ title, url, des, logo, catelog, onClick, index, isSearching, noI
       className="card-box"
     >
       {showNumIndex && <span className="card-index">{index + 1}</span>}
-      <div className="card-content">
+      <div className={`card-content ${compactMode ? 'compact-mode' : ''}`}>
         {!noImageMode && (
           <div className="card-left">
             {el}
@@ -39,9 +39,9 @@ const Card = ({ title, url, des, logo, catelog, onClick, index, isSearching, noI
         <div className="card-right">
           <div className="card-right-top">
             <span className="card-right-title" title={title}>{title}</span>
-            <span className="card-tag" title={displayCatelog}>{displayCatelog}</span>
+            {!compactMode && <span className="card-tag" title={displayCatelog}>{displayCatelog}</span>}
           </div>
-          <div className="card-right-bottom" title={des}>{des}</div>
+          {!compactMode && <div className="card-right-bottom" title={des}>{des}</div>}
         </div>
       </div>
     </a>

--- a/ui/src/components/CardV2/index.tsx
+++ b/ui/src/components/CardV2/index.tsx
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import "./index.css";
 import { getLogoUrl } from "../../utils/check";
 import { getJumpTarget } from "../../utils/setting";
-const Card = ({ title, url, des, logo, catelog, onClick, index, isSearching }) => {
+const Card = ({ title, url, des, logo, catelog, onClick, index, isSearching, noImageMode }) => {
   const el = useMemo(() => {
     if (url === "admin") {
       return <img src={logo} alt={title} />
@@ -31,14 +31,11 @@ const Card = ({ title, url, des, logo, catelog, onClick, index, isSearching }) =
     >
       {showNumIndex && <span className="card-index">{index + 1}</span>}
       <div className="card-content">
-        <div className="card-left">
-          {el}
-          {/* {url === "admin" ? (
-            <img src={logo} alt={title} />
-          ) : (
-            <img src={`/api/img?url=${logo}`} alt={title} />
-          )} */}
-        </div>
+        {!noImageMode && (
+          <div className="card-left">
+            {el}
+          </div>
+        )}
         <div className="card-right">
           <div className="card-right-top">
             <span className="card-right-title" title={title}>{title}</span>

--- a/ui/src/components/CardV2/index.tsx
+++ b/ui/src/components/CardV2/index.tsx
@@ -6,16 +6,36 @@ import { getJumpTarget } from "../../utils/setting";
 const Card = ({ title, url, des, logo, catelog, onClick, index, isSearching, noImageMode, compactMode }) => {
   const [imageLoaded, setImageLoaded] = useState(false);
   const [imageError, setImageError] = useState(false);
+  const [showLoading, setShowLoading] = useState(true);
   
   const imageSrc = useMemo(() => {
     return url === "admin" ? logo : getLogoUrl(logo);
   }, [logo, url]);
   
-  // 当图片源变化时重置状态
+  // 当图片源变化时重置状态，并添加超时保护
   useEffect(() => {
     setImageLoaded(false);
     setImageError(false);
+    setShowLoading(true);
+    
+    // 10秒超时保护
+    const timeout = setTimeout(() => {
+      setShowLoading(false);
+      console.warn('Image loading timeout:', imageSrc);
+    }, 10000);
+    
+    return () => clearTimeout(timeout);
   }, [imageSrc]);
+  
+  const handleImageLoad = () => {
+    setImageLoaded(true);
+    setShowLoading(false);
+  };
+  
+  const handleImageError = () => {
+    setImageError(true);
+    setShowLoading(false);
+  };
   
   const el = useMemo(() => {
     if (imageError) {
@@ -30,15 +50,15 @@ const Card = ({ title, url, des, logo, catelog, onClick, index, isSearching, noI
     
     return (
       <>
-        {!imageLoaded && (
+        {showLoading && !imageLoaded && (
           <div className="card-loading-spinner"></div>
         )}
         <img 
           src={imageSrc}
           alt={title}
           loading="lazy"
-          onLoad={() => setImageLoaded(true)}
-          onError={() => setImageError(true)}
+          onLoad={handleImageLoad}
+          onError={handleImageError}
           style={{
             opacity: imageLoaded ? 1 : 0.1,
             transition: 'opacity 0.3s ease'
@@ -46,7 +66,7 @@ const Card = ({ title, url, des, logo, catelog, onClick, index, isSearching, noI
         />
       </>
     );
-  }, [imageSrc, title, imageLoaded, imageError]);
+  }, [imageSrc, title, imageLoaded, imageError, showLoading]);
   
   // 处理空分类，显示为"未分类"
   const displayCatelog = useMemo(() => {

--- a/ui/src/components/CardV2/index.tsx
+++ b/ui/src/components/CardV2/index.tsx
@@ -1,15 +1,52 @@
-import { useMemo } from "react";
+import { useMemo, useState, useEffect } from "react";
 import "./index.css";
 import { getLogoUrl } from "../../utils/check";
 import { getJumpTarget } from "../../utils/setting";
+
 const Card = ({ title, url, des, logo, catelog, onClick, index, isSearching, noImageMode, compactMode }) => {
+  const [imageLoaded, setImageLoaded] = useState(false);
+  const [imageError, setImageError] = useState(false);
+  
+  const imageSrc = useMemo(() => {
+    return url === "admin" ? logo : getLogoUrl(logo);
+  }, [logo, url]);
+  
+  // 当图片源变化时重置状态
+  useEffect(() => {
+    setImageLoaded(false);
+    setImageError(false);
+  }, [imageSrc]);
+  
   const el = useMemo(() => {
-    if (url === "admin") {
-      return <img src={logo} alt={title} />
-    } else {
-        return <img src={getLogoUrl(logo)} alt={title} />
+    if (imageError) {
+      return <div style={{ 
+        display: 'flex', 
+        alignItems: 'center', 
+        justifyContent: 'center',
+        fontSize: '20px',
+        opacity: 0.6
+      }}>🖼️</div>;
     }
-  }, [logo, title, url])
+    
+    return (
+      <>
+        {!imageLoaded && (
+          <div className="card-loading-spinner"></div>
+        )}
+        <img 
+          src={imageSrc}
+          alt={title}
+          loading="lazy"
+          onLoad={() => setImageLoaded(true)}
+          onError={() => setImageError(true)}
+          style={{
+            opacity: imageLoaded ? 1 : 0.1,
+            transition: 'opacity 0.3s ease'
+          }}
+        />
+      </>
+    );
+  }, [imageSrc, title, imageLoaded, imageError]);
   
   // 处理空分类，显示为"未分类"
   const displayCatelog = useMemo(() => {

--- a/ui/src/components/CardV2/index.tsx
+++ b/ui/src/components/CardV2/index.tsx
@@ -10,6 +10,14 @@ const Card = ({ title, url, des, logo, catelog, onClick, index, isSearching }) =
         return <img src={getLogoUrl(logo)} alt={title} />
     }
   }, [logo, title, url])
+  
+  // 处理空分类，显示为"未分类"
+  const displayCatelog = useMemo(() => {
+    return catelog === null || catelog === undefined || catelog === "" || (typeof catelog === 'string' && catelog.trim() === "") 
+      ? "未分类" 
+      : catelog;
+  }, [catelog]);
+  
   const showNumIndex = index < 10 && isSearching;
   return (
     <a
@@ -34,7 +42,7 @@ const Card = ({ title, url, des, logo, catelog, onClick, index, isSearching }) =
         <div className="card-right">
           <div className="card-right-top">
             <span className="card-right-title" title={title}>{title}</span>
-            <span className="card-tag" title={catelog}>{catelog}</span>
+            <span className="card-tag" title={displayCatelog}>{displayCatelog}</span>
           </div>
           <div className="card-right-bottom" title={des}>{des}</div>
         </div>

--- a/ui/src/components/Content/index.css
+++ b/ui/src/components/Content/index.css
@@ -619,3 +619,116 @@
   text-decoration: none;
   color: #bbb;
 }
+
+/* 精简模式样式 - 6列布局 */
+@media (min-width: 1060px) {
+  .content.compact-grid {
+    grid-template-columns: repeat(6, minmax(149px, 175px));
+    grid-auto-rows: 48px;
+    grid-gap: 10px;
+    max-width: 1170px;
+    margin: 0 auto;
+  }
+  
+  .content.compact-grid .card-box {
+    padding: 8px 12px;
+    max-width: none;
+    min-height: 48px;
+    height: 48px;
+    display: flex;
+    align-items: center;
+  }
+  
+  .content.compact-grid .card-box:hover {
+    transform: none;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    background-color: #f0f1f3;
+  }
+}
+
+@media (max-width: 1060px) and (min-width: 700px) {
+  .content.compact-grid {
+    grid-template-columns: repeat(4, minmax(140px, 160px));
+    grid-auto-rows: 42px;
+    grid-gap: 8px;
+    max-width: 720px;
+    margin: 0 auto;
+  }
+  
+  .content.compact-grid .card-box {
+    padding: 6px 10px;
+    max-width: none;
+    min-height: 42px;
+    height: 42px;
+    display: flex;
+    align-items: center;
+  }
+  
+  .content.compact-grid .card-box:hover {
+    transform: none;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+    background-color: #f0f1f3;
+  }
+}
+
+@media (max-width: 700px) and (min-width: 500px) {
+  .content.compact-grid {
+    grid-template-columns: repeat(3, minmax(120px, 150px));
+    grid-auto-rows: 36px;
+    grid-gap: 6px;
+    max-width: 480px;
+    margin: 0 auto;
+  }
+  
+  .content.compact-grid .card-box {
+    padding: 4px 8px;
+    max-width: none;
+    min-height: 36px;
+    height: 36px;
+    display: flex;
+    align-items: center;
+  }
+  
+  .content.compact-grid .card-box:hover {
+    transform: none;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.1);
+    background-color: #f0f1f3;
+  }
+}
+
+@media (max-width: 500px) {
+  .content.compact-grid {
+    grid-template-columns: repeat(2, minmax(140px, 180px));
+    grid-auto-rows: 32px;
+    grid-gap: 8px;
+    max-width: 400px;
+    margin: 0 auto;
+  }
+  
+  .content.compact-grid .card-box {
+    padding: 4px 6px;
+    max-width: none;
+    min-height: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+  }
+  
+  .content.compact-grid .card-box:hover {
+    transform: none;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.1);
+    background-color: #f0f1f3;
+  }
+}
+
+/* 暗色模式下的精简模式样式 */
+body.dark-mode .content.compact-grid .card-box {
+  background-color: #2a2a2a;
+}
+
+body.dark-mode .content.compact-grid .card-box:hover {
+  background-color: #3a3a3a;
+  box-shadow: 0 2px 8px rgba(255,255,255,0.1);
+}
+
+

--- a/ui/src/components/Content/index.tsx
+++ b/ui/src/components/Content/index.tsx
@@ -154,6 +154,7 @@ const Content = (props: any) => {
           index={index}
           isSearching={searchString.trim() !== ""}
           noImageMode={data?.siteConfig?.noImageMode || false}
+          compactMode={data?.siteConfig?.compactMode || false}
           onClick={() => {
             resetSearch();
             if (item.url === "toggleJumpTarget") {
@@ -165,7 +166,7 @@ const Content = (props: any) => {
       );
     });
     // eslint-disable-next-line
-  }, [filteredData, searchString, data?.siteConfig?.noImageMode]);
+  }, [filteredData, searchString, data?.siteConfig?.noImageMode, data?.siteConfig?.compactMode]);
 
   const onKeyEnter = (ev: KeyboardEvent) => {
     const cards = filteredDataRef.current;
@@ -219,7 +220,7 @@ const Content = (props: any) => {
         </div>
       </div>
       <div className="content-wraper">
-        <div className="content cards">
+        <div className={`content cards ${data?.siteConfig?.compactMode ? 'compact-grid' : ''}`}>
           {loading ? <Loading></Loading> : renderCardsV2()}
         </div>
       </div>

--- a/ui/src/components/Content/index.tsx
+++ b/ui/src/components/Content/index.tsx
@@ -27,6 +27,7 @@ const Content = (props: any) => {
   const [currTag, setCurrTag] = useState("全部工具");
   const [searchString, setSearchString] = useState("");
   const [val, setVal] = useState("");
+  const [searchEngineCards, setSearchEngineCards] = useState<any[]>([]);
 
   const filteredDataRef = useRef<any>([]);
 
@@ -34,6 +35,7 @@ const Content = (props: any) => {
     const hide = data?.setting?.hideGithub === true
     return !hide;
   }, [data])
+  
   const loadData = useCallback(async () => {
     try {
       setLoading(true);
@@ -51,9 +53,25 @@ const Content = (props: any) => {
       setLoading(false);
     }
   }, [setData, setLoading, setCurrTag]);
+  
   useEffect(() => {
     loadData();
   }, [loadData]);
+
+  // 异步加载搜索引擎卡片
+  useEffect(() => {
+    const loadSearchEngineCards = async () => {
+      try {
+        const cards = await generateSearchEngineCard(searchString);
+        setSearchEngineCards(cards);
+      } catch (error) {
+        console.error('加载搜索引擎卡片失败:', error);
+        setSearchEngineCards([]);
+      }
+    };
+
+    loadSearchEngineCards();
+  }, [searchString]);
 
   const handleSetCurrTag = (tag: string) => {
     setCurrTag(tag);
@@ -82,8 +100,6 @@ const Content = (props: any) => {
     }
   }
 
-
-
   const filteredData = useMemo(() => {
     if (data.tools) {
       const localResult = data.tools
@@ -103,11 +119,11 @@ const Content = (props: any) => {
             mutiSearch(item.url, searchString)
           );
         });
-      return [...localResult, ...generateSearchEngineCard(searchString)]
+      return [...localResult, ...searchEngineCards]
     } else {
-      return [...generateSearchEngineCard(searchString)];
+      return [...searchEngineCards];
     }
-  }, [data, currTag, searchString]);
+  }, [data, currTag, searchString, searchEngineCards]);
 
   useEffect(() => {
     filteredDataRef.current = filteredData

--- a/ui/src/components/Content/index.tsx
+++ b/ui/src/components/Content/index.tsx
@@ -153,6 +153,7 @@ const Content = (props: any) => {
           catelog={item.catelog}
           index={index}
           isSearching={searchString.trim() !== ""}
+          noImageMode={data?.siteConfig?.noImageMode || false}
           onClick={() => {
             resetSearch();
             if (item.url === "toggleJumpTarget") {
@@ -164,7 +165,7 @@ const Content = (props: any) => {
       );
     });
     // eslint-disable-next-line
-  }, [filteredData, searchString]);
+  }, [filteredData, searchString, data?.siteConfig?.noImageMode]);
 
   const onKeyEnter = (ev: KeyboardEvent) => {
     const cards = filteredDataRef.current;

--- a/ui/src/components/TagSelector/index.tsx
+++ b/ui/src/components/TagSelector/index.tsx
@@ -9,6 +9,11 @@ const TagSelector = (props: TagSelectorProps) => {
   const { tags = ["all"], onTagChange, currTag } = props;
   const renderTags = useCallback(() => {
     const originTags =  tags.map((each) => {
+      // 处理空分类，显示为"未分类"
+      const displayText = each === null || each === undefined || each === "" || (typeof each === 'string' && each.trim() === "") 
+        ? "未分类" 
+        : each;
+      
       return (
         <span
           className={`select-tag ${
@@ -19,7 +24,7 @@ const TagSelector = (props: TagSelectorProps) => {
             onTagChange(each);
           }}
         >
-          {each}
+          {displayText}
         </span>
       );
     });

--- a/ui/src/pages/admin/components/sidebar.tsx
+++ b/ui/src/pages/admin/components/sidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 
 export interface MenuItem {
@@ -20,7 +20,17 @@ export const Sidebar: React.FC<SidebarProps> = ({
   onChange
 }) => {
   const location = useLocation();
-  const [expanded, setExpanded] = useState(false);
+  
+  // 从localStorage读取侧边栏展开状态，默认为false
+  const [expanded, setExpanded] = useState(() => {
+    const saved = localStorage.getItem('admin-sidebar-expanded');
+    return saved ? JSON.parse(saved) : false;
+  });
+
+  // 当展开状态改变时，保存到localStorage
+  useEffect(() => {
+    localStorage.setItem('admin-sidebar-expanded', JSON.stringify(expanded));
+  }, [expanded]);
 
   return (
     <div className={`h-full bg-white border-r border-gray-200 transition-all duration-300 relative

--- a/ui/src/pages/admin/index.tsx
+++ b/ui/src/pages/admin/index.tsx
@@ -8,6 +8,7 @@ import {
   GearIcon,
   BackpackIcon,
   TableIcon,
+  MagnifyingGlassIcon,
 } from '@radix-ui/react-icons';
 import { useOnce } from '../../utils/useOnce';
 
@@ -23,6 +24,12 @@ const menuItems: MenuItem[] = [
     icon: <TableIcon className="w-5 h-5" />,
     label: '分类管理',
     path: '/admin/categories'
+  },
+  {
+    key: 'search-engines',
+    icon: <MagnifyingGlassIcon className="w-5 h-5" />,
+    label: '搜索引擎管理',
+    path: '/admin/search-engines'
   },
   {
     key: 'api-token',

--- a/ui/src/pages/admin/tabs/Search.tsx
+++ b/ui/src/pages/admin/tabs/Search.tsx
@@ -49,12 +49,22 @@ const DraggableRow = ({ children, ...props }: any) => {
     ...props.style,
     transform: CSS.Transform.toString(transform),
     transition,
-    cursor: 'move',
     ...(isDragging ? { zIndex: 9999 } : {}),
   };
 
+  // 使用CSS类选择器来限制拖拽区域
+  const modifiedListeners = {
+    ...listeners,
+    onPointerDown: (e: any) => {
+      // 只有点击在拖拽区域时才触发拖拽
+      if (e.target.closest('.drag-handle')) {
+        listeners.onPointerDown?.(e);
+      }
+    }
+  };
+
   return (
-    <tr {...props} ref={setNodeRef} style={style} {...attributes} {...listeners}>
+    <tr {...props} ref={setNodeRef} style={style} {...attributes} {...modifiedListeners}>
       {children}
     </tr>
   );
@@ -89,8 +99,21 @@ const SearchEngineManager: React.FC = () => {
     {
       title: '排序',
       dataIndex: 'sort',
-      width: 30,
-      render: () => <DragOutlined style={{ cursor: 'move', color: '#999' }} />,
+      width: 60,
+      render: (_: any, record: SearchEngine) => (
+        <div 
+          className="drag-handle"
+          style={{ 
+            cursor: 'move', 
+            padding: '8px',
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center'
+          }}
+        >
+          <DragOutlined style={{ color: '#999' }} />
+        </div>
+      ),
     },
     {
       title: 'Logo',

--- a/ui/src/pages/admin/tabs/Search.tsx
+++ b/ui/src/pages/admin/tabs/Search.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Table,
   Button,
@@ -7,49 +7,31 @@ import {
   Input,
   Space,
   message,
-  Upload,
   Image,
+  Switch,
+  Spin,
 } from 'antd';
 import { DragOutlined, DeleteOutlined, EditOutlined, PlusOutlined } from '@ant-design/icons';
 import { DndContext } from '@dnd-kit/core';
 import { SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
+import {
+  fetchGetAllSearchEngines,
+  fetchAddSearchEngine,
+  fetchUpdateSearchEngine,
+  fetchDeleteSearchEngine,
+  fetchUpdateSearchEnginesSort,
+} from '../../../utils/api';
 
 interface SearchEngine {
-  id: string;
+  id: number;
   name: string;
   baseUrl: string;
   queryParam: string;
   logo: string;
-  order: number;
+  sort: number;
+  enabled: boolean;
 }
-
-const defaultEngines: SearchEngine[] = [
-  {
-    id: '1',
-    name: '百度',
-    baseUrl: 'https://www.baidu.com/s',
-    queryParam: 'wd',
-    logo: 'https://www.baidu.com/favicon.ico',
-    order: 1,
-  },
-  {
-    id: '2',
-    name: 'Google',
-    baseUrl: 'https://www.google.com/search',
-    queryParam: 'q',
-    logo: 'https://www.google.com/favicon.ico',
-    order: 2,
-  },
-  {
-    id: '3',
-    name: 'Bing',
-    baseUrl: 'https://www.bing.com/search',
-    queryParam: 'q',
-    logo: 'https://www.bing.com/favicon.ico',
-    order: 3,
-  },
-];
 
 const DraggableRow = ({ children, ...props }: any) => {
   const {
@@ -79,10 +61,29 @@ const DraggableRow = ({ children, ...props }: any) => {
 };
 
 const SearchEngineManager: React.FC = () => {
-  const [engines, setEngines] = useState<SearchEngine[]>(defaultEngines);
+  const [engines, setEngines] = useState<SearchEngine[]>([]);
+  const [loading, setLoading] = useState(false);
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [editingEngine, setEditingEngine] = useState<SearchEngine | null>(null);
   const [form] = Form.useForm();
+
+  // 加载搜索引擎数据
+  const loadEngines = async () => {
+    try {
+      setLoading(true);
+      const data = await fetchGetAllSearchEngines();
+      setEngines(data);
+    } catch (error) {
+      message.error('加载搜索引擎失败');
+      console.error(error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadEngines();
+  }, []);
 
   const columns = [
     {
@@ -95,8 +96,14 @@ const SearchEngineManager: React.FC = () => {
       title: 'Logo',
       dataIndex: 'logo',
       width: 80,
-      render: (logo: string) => (
-        <Image src={logo} alt="logo" width={24} height={24} />
+      render: (logo: string, record: SearchEngine) => (
+        <Image 
+          src={logo.startsWith('http') ? logo : `/api/img?url=${logo}`} 
+          alt={record.name} 
+          width={24} 
+          height={24}
+          fallback="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMIAAADDCAYAAADQvc6UAAABRWlDQ1BJQ0MgUHJvZmlsZQAAKJFjYGASSSwoyGFhYGDIzSspCnJ3UoiIjFJgf8LAwSDCIMogwMCcmFxc4BgQ4ANUwgCjUcG3awyMIPqyLsis7PPOq3QdDFcvjV3jOD1boQVTPQrgSkktTgbSf4A4LbmgqISBgTEFyFYuLykAsTuAbJEioKOA7DkgdjqEvQHEToKwj4DVhAQ5A9k3gGyB5IxEoBmML4BsnSQk8XQkNtReEOBxcfXxUQg1Mjc0dyHgXNJBSWpFCYh2zi+oLMpMzyhRcASGUqqCZ16yno6CkYGRAQMDKMwhqj/fAIcloxgHQqxAjIHBEugw5sUIsSQpBobtQPdLciLEVJYzMPBHMDBsayhILEqEO4DxG0txmrERhM29nYGBddr//5/DGRjYNRkY/l7////39v///y4Dmn+LgeHANwDrkl1AuO+pmgAAADhlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAAqACAAQAAAABAAAAwqADAAQAAAABAAAAwwAAAAD9b/HnAAAHlklEQVR4Ae3dP3Ik1RnG4W+FgYxN"
+        />
       ),
     },
     {
@@ -108,8 +115,18 @@ const SearchEngineManager: React.FC = () => {
       dataIndex: 'baseUrl',
     },
     {
-      title: '查询参��',
+      title: '查询参数',
       dataIndex: 'queryParam',
+    },
+    {
+      title: '启用',
+      dataIndex: 'enabled',
+      render: (enabled: boolean, record: SearchEngine) => (
+        <Switch
+          checked={enabled}
+          onChange={(checked) => handleToggleEnabled(record, checked)}
+        />
+      ),
     },
     {
       title: '操作',
@@ -132,15 +149,32 @@ const SearchEngineManager: React.FC = () => {
     },
   ];
 
+  const handleToggleEnabled = async (engine: SearchEngine, enabled: boolean) => {
+    try {
+      await fetchUpdateSearchEngine({ ...engine, enabled });
+      message.success('更新成功');
+      loadEngines();
+    } catch (error) {
+      message.error('更新失败');
+      console.error(error);
+    }
+  };
+
   const handleEdit = (engine: SearchEngine) => {
     setEditingEngine(engine);
     form.setFieldsValue(engine);
     setIsModalVisible(true);
   };
 
-  const handleDelete = (id: string) => {
-    setEngines(engines.filter((engine) => engine.id !== id));
-    message.success('删除成功');
+  const handleDelete = async (id: number) => {
+    try {
+      await fetchDeleteSearchEngine(id);
+      message.success('删除成功');
+      loadEngines();
+    } catch (error) {
+      message.error('删除失败');
+      console.error(error);
+    }
   };
 
   const handleAdd = () => {
@@ -153,28 +187,20 @@ const SearchEngineManager: React.FC = () => {
     try {
       const values = await form.validateFields();
       if (editingEngine) {
-        setEngines(
-          engines.map((engine) =>
-            engine.id === editingEngine.id ? { ...engine, ...values } : engine
-          )
-        );
+        await fetchUpdateSearchEngine({ ...values, id: editingEngine.id });
         message.success('修改成功');
       } else {
-        const newEngine = {
-          ...values,
-          id: Date.now().toString(),
-          order: engines.length + 1,
-        };
-        setEngines([...engines, newEngine]);
+        await fetchAddSearchEngine({ ...values, enabled: true });
         message.success('添加成功');
       }
       setIsModalVisible(false);
+      loadEngines();
     } catch (error) {
       console.error('Validate Failed:', error);
     }
   };
 
-  const onDragEnd = ({ active, over }: any) => {
+  const onDragEnd = async ({ active, over }: any) => {
     if (active.id !== over?.id) {
       const activeIndex = engines.findIndex((i) => i.id === active.id);
       const overIndex = engines.findIndex((i) => i.id === over?.id);
@@ -184,11 +210,24 @@ const SearchEngineManager: React.FC = () => {
 
       const reorderedItems = newItems.map((item, index) => ({
         ...item,
-        order: index + 1,
+        sort: index + 1,
       }));
 
       setEngines(reorderedItems);
-      message.success('排序已更新');
+
+      try {
+        const updates = reorderedItems.map((item, index) => ({
+          id: item.id,
+          sort: index + 1,
+        }));
+        await fetchUpdateSearchEnginesSort(updates);
+        message.success('排序已更新');
+      } catch (error) {
+        message.error('排序更新失败');
+        console.error(error);
+        // 如果失败，重新加载数据
+        loadEngines();
+      }
     }
   };
 
@@ -200,23 +239,26 @@ const SearchEngineManager: React.FC = () => {
         </Button>
       </div>
 
-      <DndContext onDragEnd={onDragEnd}>
-        <SortableContext
-          items={engines.map((i) => i.id)}
-          strategy={verticalListSortingStrategy}
-        >
-          <Table
-            columns={columns}
-            dataSource={engines}
-            rowKey="id"
-            components={{
-              body: {
-                row: DraggableRow,
-              },
-            }}
-          />
-        </SortableContext>
-      </DndContext>
+      <Spin spinning={loading}>
+        <DndContext onDragEnd={onDragEnd}>
+          <SortableContext
+            items={engines.map((i) => i.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            <Table
+              columns={columns}
+              dataSource={engines}
+              rowKey="id"
+              components={{
+                body: {
+                  row: DraggableRow,
+                },
+              }}
+              pagination={false}
+            />
+          </SortableContext>
+        </DndContext>
+      </Spin>
 
       <Modal
         title={editingEngine ? '编辑搜索引擎' : '添加搜索引擎'}
@@ -230,28 +272,28 @@ const SearchEngineManager: React.FC = () => {
             label="名称"
             rules={[{ required: true, message: '请输入搜索引擎名称' }]}
           >
-            <Input />
+            <Input placeholder="例如：百度" />
           </Form.Item>
           <Form.Item
             name="baseUrl"
             label="基础URL"
             rules={[{ required: true, message: '请输入基础URL' }]}
           >
-            <Input />
+            <Input placeholder="例如：https://www.baidu.com/s" />
           </Form.Item>
           <Form.Item
             name="queryParam"
             label="查询参数"
             rules={[{ required: true, message: '请输入查询参数' }]}
           >
-            <Input />
+            <Input placeholder="例如：wd" />
           </Form.Item>
           <Form.Item
             name="logo"
-            label="Logo URL"
-            rules={[{ required: true, message: '请输入Logo URL' }]}
+            label="Logo文件名"
+            rules={[{ required: true, message: '请输入Logo文件名' }]}
           >
-            <Input />
+            <Input placeholder="例如：baidu.ico（需要先上传到public目录）" />
           </Form.Item>
         </Form>
       </Modal>

--- a/ui/src/pages/admin/tabs/Search.tsx
+++ b/ui/src/pages/admin/tabs/Search.tsx
@@ -313,10 +313,28 @@ const SearchEngineManager: React.FC = () => {
           </Form.Item>
           <Form.Item
             name="logo"
-            label="Logo文件名"
-            rules={[{ required: true, message: '请输入Logo文件名' }]}
+            label="Logo"
+            rules={[
+              { required: true, message: '请输入Logo文件名或网址' },
+              {
+                validator: (_, value) => {
+                  if (!value) return Promise.resolve();
+                  
+                  // 检查是否是有效的URL
+                  const urlPattern = /^https?:\/\/.+/i;
+                  // 检查是否是文件名（包含文件扩展名）
+                  const filePattern = /\.(ico|png|jpg|jpeg|gif|svg|webp)$/i;
+                  
+                  if (urlPattern.test(value) || filePattern.test(value)) {
+                    return Promise.resolve();
+                  }
+                  
+                  return Promise.reject(new Error('请输入有效的网址(http/https)或图标文件名(.ico/.png/.jpg等)'));
+                }
+              }
+            ]}
           >
-            <Input placeholder="例如：baidu.ico（需要先上传到public目录）" />
+            <Input placeholder="例如：baidu.ico 或 https://example.com/logo.png" />
           </Form.Item>
         </Form>
       </Modal>

--- a/ui/src/pages/admin/tabs/Setting.tsx
+++ b/ui/src/pages/admin/tabs/Setting.tsx
@@ -1,15 +1,17 @@
 import { Button, Card, Form, Input, message, Select, Spin, Switch } from "antd";
 import { useCallback, useEffect } from "react";
-import { fetchUpdateSetting, fetchUpdateUser } from "../../../utils/api";
+import { fetchUpdateSetting, fetchUpdateUser, fetchUpdateSiteConfig } from "../../../utils/api";
 import { useData } from "../hooks/useData";
 export interface SettingProps { }
 export const Setting: React.FC<SettingProps> = (props) => {
   const { store, loading, reload } = useData();
   const [userForm] = Form.useForm();
   const [settingForm] = Form.useForm();
+  const [siteConfigForm] = Form.useForm();
   useEffect(() => {
     userForm.setFieldsValue(store?.user ?? {})
     settingForm.setFieldsValue(store?.setting ?? {})
+    siteConfigForm.setFieldsValue(store?.siteConfig ?? {})
   }, [store])
   const handleUpdateUser = useCallback(
     async (values: any) => {
@@ -28,6 +30,19 @@ export const Setting: React.FC<SettingProps> = (props) => {
     async (values: any) => {
       try {
         await fetchUpdateSetting(values);
+        message.success("修改成功!");
+      } catch (err) {
+        message.warning("修改失败!");
+      } finally {
+        reload();
+      }
+    },
+    [reload]
+  );
+  const handleUpdateSiteConfig = useCallback(
+    async (values: any) => {
+      try {
+        await fetchUpdateSiteConfig(values);
         message.success("修改成功!");
       } catch (err) {
         message.warning("修改失败!");
@@ -144,6 +159,25 @@ export const Setting: React.FC<SettingProps> = (props) => {
             </Form.Item>
             <Form.Item label="隐藏 Github 按钮" name="hideGithub" tooltip="默认展示，开启后将在前台 Github 按钮" >
               <Switch defaultChecked={Boolean(store?.setting?.hideGithub)} />
+            </Form.Item>
+            <Form.Item wrapperCol={{ offset: 8, span: 16 }}>
+              <Button type="primary" htmlType="submit">
+                提交
+              </Button>
+            </Form.Item>
+          </Form>
+        </Spin>
+      </Card>
+      <Card title={`修改网站配置`} style={{ marginTop: 32 }}>
+        <Spin spinning={loading}>
+          <Form
+            onFinish={handleUpdateSiteConfig}
+            initialValues={store?.siteConfig ?? {}}
+            labelCol={{ span: 6 }}
+            form={siteConfigForm}
+          >
+            <Form.Item label="无图模式" name="noImageMode" tooltip="开启后前台将不展示工具logo等图片">
+              <Switch defaultChecked={Boolean(store?.siteConfig?.noImageMode)} />
             </Form.Item>
             <Form.Item wrapperCol={{ offset: 8, span: 16 }}>
               <Button type="primary" htmlType="submit">

--- a/ui/src/pages/admin/tabs/Setting.tsx
+++ b/ui/src/pages/admin/tabs/Setting.tsx
@@ -179,6 +179,9 @@ export const Setting: React.FC<SettingProps> = (props) => {
             <Form.Item label="无图模式" name="noImageMode" tooltip="开启后前台将不展示工具logo等图片">
               <Switch defaultChecked={Boolean(store?.siteConfig?.noImageMode)} />
             </Form.Item>
+            <Form.Item label="精简模式" name="compactMode" tooltip="开启后卡片只显示标题和logo，如果同时开启无图模式则只显示标题">
+              <Switch defaultChecked={Boolean(store?.siteConfig?.compactMode)} />
+            </Form.Item>
             <Form.Item wrapperCol={{ offset: 8, span: 16 }}>
               <Button type="primary" htmlType="submit">
                 提交

--- a/ui/src/pages/admin/tabs/Tools.tsx
+++ b/ui/src/pages/admin/tabs/Tools.tsx
@@ -437,6 +437,8 @@ export const Tools: React.FC<ToolsProps> = (props) => {
                           src={`/api/img?url=${record.logo}`}
                           width={32}
                           height={32}
+                          loading="lazy"
+                          style={{ objectFit: 'cover' }}
                         ></img>
                       <span style={{ marginLeft: 8 }}>{record.name}</span>
                     </div>

--- a/ui/src/utils/api.tsx
+++ b/ui/src/utils/api.tsx
@@ -148,3 +148,41 @@ export const fetchUpdateToolsSort = async (updates: { id: number; sort: number }
     const { data } = await axios.put(`/api/admin/tools/sort`, updates);
     return data?.data || {};
 };
+
+// ==================== 搜索引擎管理接口 ====================
+
+// 获取所有搜索引擎（管理员用）
+export const fetchGetAllSearchEngines = async () => {
+    const { data } = await axios.get(`/api/admin/searchEngine`);
+    return data?.data || [];
+};
+
+// 获取启用的搜索引擎（前端搜索用）
+export const fetchGetEnabledSearchEngines = async () => {
+    const { data } = await axios.get(`/api/searchEngines`);
+    return data?.data || [];
+};
+
+// 添加搜索引擎
+export const fetchAddSearchEngine = async (payload: any) => {
+    const { data } = await axios.post(`/api/admin/searchEngine`, payload);
+    return data?.data || {};
+};
+
+// 更新搜索引擎
+export const fetchUpdateSearchEngine = async (payload: any) => {
+    const { data } = await axios.put(`/api/admin/searchEngine/${payload.id}`, payload);
+    return data?.data || {};
+};
+
+// 删除搜索引擎
+export const fetchDeleteSearchEngine = async (id: number) => {
+    const { data } = await axios.delete(`/api/admin/searchEngine/${id}`);
+    return data?.data || {};
+};
+
+// 更新搜索引擎排序
+export const fetchUpdateSearchEnginesSort = async (updates: { id: number; sort: number }[]) => {
+    const { data } = await axios.put(`/api/admin/searchEngines/sort`, updates);
+    return data?.data || {};
+};

--- a/ui/src/utils/api.tsx
+++ b/ui/src/utils/api.tsx
@@ -131,6 +131,11 @@ export const fetchUpdateSetting = async (payload: any) => {
     return data?.data || {};
 };
 
+export const fetchUpdateSiteConfig = async (payload: any) => {
+    const { data } = await axios.put(`/api/admin/siteConfig`, payload);
+    return data?.data || {};
+};
+
 export const fetchUpdateUser = async (payload: any) => {
     const { data } = await axios.put(`/api/admin/user`, payload);
     return data?.data || {};

--- a/ui/src/utils/serachEngine.ts
+++ b/ui/src/utils/serachEngine.ts
@@ -1,44 +1,96 @@
-export const generateSearchEngineCard = (searchString: string) => {
+import { fetchGetEnabledSearchEngines } from './api';
+
+// 搜索引擎缓存
+let searchEnginesCache: any[] = [];
+let cacheExpiry = 0;
+const CACHE_DURATION = 5 * 60 * 1000; // 5分钟缓存
+
+// 获取启用的搜索引擎
+const getEnabledSearchEngines = async () => {
+  const now = Date.now();
+  
+  // 如果缓存有效，直接返回缓存
+  if (searchEnginesCache.length > 0 && now < cacheExpiry) {
+    return searchEnginesCache;
+  }
+  
+  try {
+    // 从API获取数据
+    searchEnginesCache = await fetchGetEnabledSearchEngines();
+    cacheExpiry = now + CACHE_DURATION;
+    return searchEnginesCache;
+  } catch (error) {
+    console.error('获取搜索引擎失败，使用默认配置:', error);
+    
+    // 如果API调用失败，使用默认搜索引擎配置
+    const defaultEngines = [
+      {
+        id: 1,
+        name: "百度",
+        baseUrl: "https://www.baidu.com/s",
+        queryParam: "wd",
+        logo: "baidu.ico",
+        sort: 1,
+        enabled: true
+      },
+      {
+        id: 2,
+        name: "Bing",
+        baseUrl: "https://cn.bing.com/search",
+        queryParam: "q",
+        logo: "bing.ico",
+        sort: 2,
+        enabled: true
+      },
+      {
+        id: 3,
+        name: "Google",
+        baseUrl: "https://www.google.com/search",
+        queryParam: "q",
+        logo: "google.ico",
+        sort: 3,
+        enabled: true
+      }
+    ];
+    
+    searchEnginesCache = defaultEngines;
+    cacheExpiry = now + CACHE_DURATION;
+    return defaultEngines;
+  }
+};
+
+// 生成搜索引擎卡片
+export const generateSearchEngineCard = async (searchString: string) => {
   if (!searchString.trim()) return [];
-  const result = [
-    {
-      name: "使用百度搜索",
-      url: searchBaidu(searchString),
-      desc: `在百度中搜索 「${searchString}」`,
-      id: 8800880001,
-      logo: "baidu.ico",
-      hide: false
-    },
-    {
-      name: "使用 Bing 搜索",
-      url: searchBing(searchString),
-      desc: `在 Bing 中搜索 「${searchString}」`,
-      id: 8800880002,
-      logo: "bing.ico",
-      hide: false
-    },
-    {
-      name: "使用 Google 搜索",
-      url: searchGoogle(searchString),
-      desc: `在 Google 中搜索 「${searchString}」`,
-      id: 8800880003,
-      logo: "google.ico",
-      hide: false
-    }
-  ]
-  return result;
-}
+  
+  try {
+    const engines = await getEnabledSearchEngines();
+    
+    return engines
+      .filter(engine => engine.enabled)
+      .sort((a, b) => a.sort - b.sort)
+      .map((engine, index) => ({
+        name: `使用 ${engine.name} 搜索`,
+        url: generateSearchUrl(engine.baseUrl, engine.queryParam, searchString),
+        desc: `在 ${engine.name} 中搜索 「${searchString}」`,
+        id: 8800880000 + engine.id, // 使用特定的ID前缀避免冲突
+        logo: engine.logo,
+        hide: false
+      }));
+  } catch (error) {
+    console.error('生成搜索引擎卡片失败:', error);
+    return [];
+  }
+};
 
+// 生成搜索URL
+const generateSearchUrl = (baseUrl: string, queryParam: string, searchString: string) => {
+  const separator = baseUrl.includes('?') ? '&' : '?';
+  return `${baseUrl}${separator}${queryParam}=${encodeURIComponent(searchString)}`;
+};
 
-
-const searchBaidu = (q: string) => {
-  return `https://www.baidu.com/s?wd=${q}`
-}
-
-const searchGoogle = (q: string) => {
-  return `https://www.google.com/search?q=${q}`
-}
-
-const searchBing = (q: string) => {
-  return `https://cn.bing.com/search?q=${q}`
-}
+// 清除缓存（当管理员修改搜索引擎配置时调用）
+export const clearSearchEngineCache = () => {
+  searchEnginesCache = [];
+  cacheExpiry = 0;
+};


### PR DESCRIPTION
1.增加搜索引擎管理功能，可拖拽排序搜索引擎。
![image](https://github.com/user-attachments/assets/f1344c45-5750-42ec-af71-068880697410)
![image](https://github.com/user-attachments/assets/5856e557-3814-4d56-a19d-46421500bd6f)
![image](https://github.com/user-attachments/assets/9126fc13-6762-46b0-acff-657290abea21)

2.导入和创建分类对空名称分类没有限制。会通过没有分类的网址导入一个空的分类。pr对空分类做了处理，无法导入和创建空分类，同时前端增加了"未分类"针对没有分类工具。
![image](https://github.com/user-attachments/assets/1f4a0ed1-9a0a-4b6e-8b3e-8d130565ab87)

3.管理员界面侧边栏增加本地存储是否展开的状态。每次刷新会从本地获取，默认不展开